### PR TITLE
Update Docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
     "vim.smartRelativeLine": true,
     "workbench.colorCustomizations": {
         "titleBar.activeBackground": "#38329A"
-    }
+    },
+    "esbonio.sphinx.confDir": ""
 }

--- a/docs/source/_functions/mpl_bsic.plot_trade.rst
+++ b/docs/source/_functions/mpl_bsic.plot_trade.rst
@@ -1,0 +1,6 @@
+﻿mpl\_bsic.plot\_trade
+=====================
+
+.. currentmodule:: mpl_bsic
+
+.. autofunction:: plot_trade

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,12 @@ pygments_style = "sphinx"
 
 # -- Options for matplotlib plots -----------------------------------------
 plot_include_source = True
+plot_formats = [("png", 900), ("pdf", 900)]
+plot_pre_code = """
+import numpy as np
+import matplotlib.pyplot as plt
+from utils.run_animations import run_animations
+"""
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ sys.path.insert(0, package_path)
 project = "mpl_bsic"
 copyright = "2023, Andrea Franceschini"
 author = "Andrea Franceschini"
-release = "1.1.6"
+release = "1.2.0"
 version = release[:3]
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,22 +2,11 @@
 
 import os
 import sys
-import re
 
 package_path = os.path.abspath("../../")
 sys.path.insert(0, package_path)
 
 
-def get_property(prop, project):
-    print(os.getcwd())
-    result = re.search(
-        r'{}\s*=\s*[\'"]([^\'"]*)[\'"]'.format(prop),
-        open("../../" + project + "/__init__.py").read(),
-    )
-    return result.group(1)
-
-
-#
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
@@ -27,7 +16,8 @@ def get_property(prop, project):
 project = "mpl_bsic"
 copyright = "2023, Andrea Franceschini"
 author = "Andrea Franceschini"
-release = get_property("__version__", "mpl_bsic")
+release = "1.1.6"
+version = release[:3]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Docs for mpl_bsic
-====================================
+Docs for mpl_bsic - Version |version| 
+===================================================
 
 ``mpl_bsic`` helps you style matplotlib plots in BSIC style.
 
@@ -109,6 +109,7 @@ Functions
 
    mpl_bsic.apply_bsic_style
    mpl_bsic.apply_bsic_logo
+   mpl_bsic.plot_trade 
    mpl_bsic.check_figsize
    mpl_bsic.format_timeseries_axis
    mpl_bsic.preprocess_dataframe

--- a/mpl_bsic/__init__.py
+++ b/mpl_bsic/__init__.py
@@ -4,6 +4,3 @@ from .check_figsize import check_figsize  # noqa
 from .format_timeseries_axis import format_timeseries_axis  # noqa
 from .plot_trade import plot_trade  # noqa
 from .preprocess_dataframe import preprocess_dataframe  # noqa
-
-__version__ = "1.1.5"
-__version_info__ = tuple([int(num) for num in __version__.split(".")])

--- a/mpl_bsic/apply_bsic_logo.py
+++ b/mpl_bsic/apply_bsic_logo.py
@@ -95,11 +95,54 @@ def apply_bsic_logo(
 
     See Also
     --------
-    TODO
+    mpl_bsic.apply_bsic_style :
+        Applies the BSIC Style to plots.
 
     Examples
     --------
-    TODO
+
+    .. plot::
+        :alt: example plot using apply_bsic_logo() (top right, formal logo)
+
+        from mpl_bsic import apply_bsic_style, apply_bsic_logo
+
+        import matplotlib.pyplot as plt
+
+        x = np.linspace(0, 5, 100)
+        y = np.cos(x)
+
+        fig, ax = plt.subplots(1, 1)
+        ax.set_title('Cos(x)') # set the title before applying the style
+        apply_bsic_style(fig, ax)
+        apply_bsic_logo(fig, ax, location='top right', scale=0.03)
+
+        ax.plot(x,y)
+        run_animations(fig) # only needed for the docs, don't call in the actual code
+
+    .. plot::
+        :alt: example plot using apply_bsic_logo() (btm left, square logo)
+
+        from mpl_bsic import apply_bsic_style, apply_bsic_logo
+
+        import matplotlib.pyplot as plt
+
+        x = np.linspace(0, 5, 100)
+        y = np.cos(x)
+
+        fig, ax = plt.subplots(1, 1)
+        ax.set_title('Cos(x)') # set the title before applying the style
+        apply_bsic_style(fig, ax)
+        apply_bsic_logo(
+            fig,
+            ax,
+            location='bottom left',
+            scale=0.05,
+            logo_type='square', # use the square logo
+            closeness_to_border=25 # make the logo closer to the border
+        )
+
+        ax.plot(x,y)
+        run_animations(fig) # only needed for the docs, don't call in the actual code
     """
 
     # gets the path for the logo and reads the image

--- a/mpl_bsic/apply_bsic_style.py
+++ b/mpl_bsic/apply_bsic_style.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import numpy as np
 from cycler import cycler
 from matplotlib import pyplot as plt
@@ -116,7 +118,7 @@ def _style_axis(fig: Figure, ax: Axes):
         ax.legend()
 
 
-def apply_bsic_style(fig: Figure, ax: Axes | np.ndarray):
+def apply_bsic_style(fig: Figure, ax: Union[Axes, np.ndarray]):
     r"""Apply the BSIC Style to an existing matplotlib plot.
 
     You can call this function at any point in your code, the BSIC style will be applied

--- a/mpl_bsic/check_figsize.py
+++ b/mpl_bsic/check_figsize.py
@@ -54,7 +54,14 @@ def check_figsize(
                 "If you do not specify height, you must specify aspect_ratio and width"
             )
 
-        height = width * aspect_ratio
+        if width > 7.32:
+            log.warning(
+                "Width is greater than 7.32 inches (the max length of a word document). Setting width to 7.32 inches."  # noqa: E501
+            )
+
+            width = 7.32
+
+        height = width / aspect_ratio
         return width, height
 
     # if you specified only height and aspect_ratio
@@ -64,7 +71,7 @@ def check_figsize(
                 "If you do not specify width, you must specify aspect_ratio and height"
             )
 
-        width = height / aspect_ratio
+        width = height * aspect_ratio
 
         # if > 7.32, set to 7.32 and recompute height
         if width > 7.32:
@@ -73,7 +80,7 @@ def check_figsize(
             )
 
             width = 7.32
-            height = width * aspect_ratio
+            height = width / aspect_ratio
 
         return width, height
 

--- a/mpl_bsic/check_figsize.py
+++ b/mpl_bsic/check_figsize.py
@@ -14,8 +14,19 @@ def check_figsize(
 
     Checks the validity of the figsize parameters
     and returns the width and height you should use for the plot.
+    You must specify at least two of the three parameters,
+    otherwise the function will return an error.
 
-    You must specify at least two of the three parameters.
+    When exporting plots for a word document, Word will resize the image automatically
+    if it doesn't fit the page. This will cause the font sizes to be inconsistent
+    across the article and the graph, with the title of the plot being
+    smaller than the usual style of the sections.
+    To avoid this, you must make sure that the width of the plot is
+    **less than 7.32 inches**,
+    which is the width of a word document available for figures.
+
+    This function makes sure that you respect the guidelines for the image size,
+    so that it won't be later resized by Word and the font sizes will be consistent.
 
     Parameters
     ----------
@@ -30,7 +41,7 @@ def check_figsize(
     Returns
     -------
     tuple[float, float]
-        The width and height to use for the Figure.
+        The *correct* width and height to use for the Figure.
 
     See Also
     --------
@@ -41,7 +52,31 @@ def check_figsize(
 
     Examples
     --------
-    This is the examples section. WIP.
+    >>> check_figsize(5, 3) # with correct width and height
+    (5, 3)
+
+    If the width is too large, it will be resized to fit a word document,
+    while keeping the original aspect ratio constant.
+
+    >>> check_figsize(10, 5) # width > 7.32
+    Width is greater than 7.32 inches.
+    This is the width of a word document available for figures.
+    If you set the width > 7.32, the figure will be resized in word and
+    the font sizes will not be consistent across the article and the graph
+    (7.32, 3.66)
+
+    You can also only specify width/height and aspect ratio,
+    and the other will be computed. Again, if the width is too large,
+    it will be resized to fit a word document.
+
+    >>> check_figsize(5, aspect_ratio=16/9) # provide width and aspect ratio
+    (5, 2.8125)
+    >>> check_figsize(10, aspect_ratio=16/9) # width is too large
+    Width is greater than 7.32 inches (the max length of a word document).
+    Setting width to 7.32 inches.
+    (7.32, 4.1175)
+    >>> check_figsize(height=3, aspect_ratio=16/9)
+    (5.33, 3)
     """
 
     if all([height is None, width is None, aspect_ratio is None]):

--- a/mpl_bsic/plot_trade.py
+++ b/mpl_bsic/plot_trade.py
@@ -131,8 +131,7 @@ def plot_trade(
     date_ticks_freq: int = 1,
     date_ticks_format: str = "%b %d, %Y",
 ):
-    """
-    Plot a trade performance vs the underlying.
+    """Plot a trade performance vs the underlying.
 
     Create a figure with two subplots. On the top, the PnL of the trade is plotted,
     while on the bottom the underlying is plotted.
@@ -189,15 +188,15 @@ def plot_trade(
         frequency, there will be 1 tick every week.
         Choose so that the axis is not cluttered.
     date_ticks_format : str, optional
-        The format used for the date ticks, by default "%b %d, %Y". I recommend
+        The format used for the date ticks, by default ``"%b %d, %Y"``. I recommend
         using the default, but you can change it to whatever
-        you find more suitable
+        you find more suitable.
 
     Returns
     -------
     tuple[matplotlib.figure.Figure, matplotlib.axes.Axes]
         A tuple containing the figure and the tuple of two axis just created.
-        You can later use this to save the fig for export, do `fig.show()`,
+        You can later use this to save the fig for export, do ``fig.show()``,
         or further customize the plot.
 
     See Also
@@ -212,8 +211,6 @@ def plot_trade(
     Examples
     --------
     Examples will come soon.
-
-
     """
     dates, entry_date = _get_dates(underlying, pnl, months_offset)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = ["Andrea Franceschini <andrea.franceschini2@studbocconi.it>"]
 readme = "README.md"
 version = "0.0.0"    
 packages = [{include = "mpl_bsic"}, {include = "utils"}]
-# testpypi v1.1.23
+# testpypi v1.1.24
 
 [tool.poetry.dependencies]
 python = ">=3.9"

--- a/tests/debug.py
+++ b/tests/debug.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from mpl_bsic import apply_bsic_logo, apply_bsic_style
+from utils.run_animations import run_animations
 
 x = np.linspace(0, 5, 100)
 y = np.cos(x)
@@ -15,5 +16,5 @@ apply_bsic_logo(fig, ax)
 ax.set_title("Cos(x)")  # set the title before applying the style
 
 ax.plot(x, y)
-
+run_animations(fig)
 plt.show()

--- a/tests/test_figsize.py
+++ b/tests/test_figsize.py
@@ -20,7 +20,7 @@ class TestFigsize:
 
         w, h = check_figsize(width, height, aspect_ratio)
 
-        assert w == height / aspect_ratio and h == 8
+        assert w == 7.32 and h - height / aspect_ratio < 1e-5
 
     def test_correct_width(self):
         width = 7.32

--- a/utils/run_animations.py
+++ b/utils/run_animations.py
@@ -1,0 +1,16 @@
+from matplotlib.figure import Figure
+
+
+def run_animations(fig: Figure):
+    if hasattr(fig, "_bsic_animations"):
+        bsic_animations = fig.__getattribute__("_bsic_animations")
+
+        for ani in bsic_animations:
+            for _ in range(5):
+                try:
+                    ani._stop = False
+                    ani._step()
+                except (
+                    AttributeError
+                ):  # catches when animation has no more frames and cannot step anymore
+                    break


### PR DESCRIPTION
# Major update for the docs

* Docs for `plot_trade` function
* Added example plots for `apply_bsic_logo`
* Created `run_animations` function in utils to force all the animations in the figure to run without displaying the plot (to be used when generating plots for the docs and in the future in tests)
* Updated `conf.py`, by specifying the output formats (png, pdf) and dpi (900) of the plots, and adding the `run_animations` import to the code which is ran before each plot 
* Version is now specified directly in `conf.py` instead of the init file of the package (unnecessary, since it was only used by Sphinx and had to be changed manually either way)
* Fixed calculations of width/height with aspect ratio in `check_figsize`, and fixed the tests consequently

Other minor changes
* Changed | to Union in `apply_bsic_style` to make it compatible with python 3.9